### PR TITLE
New usage support

### DIFF
--- a/packages/mustard-cli/source/FactoryUsage/Factory.ts
+++ b/packages/mustard-cli/source/FactoryUsage/Factory.ts
@@ -1,0 +1,5 @@
+class CommandFactory {
+  public static registerCommand() {}
+}
+
+export const { registerCommand } = CommandFactory;


### PR DESCRIPTION
This PR is adding a new way to use Mustard:

```typescript
App.configure({
  enableUsage: true
}).registerCommand((Command) => {
  Command.registerOption({
    name: 'dry',
    alias: 'd'
  });
})
```